### PR TITLE
Error() method, reduce error scope

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Jason Kingsbury
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pool_test.go
+++ b/pool_test.go
@@ -133,3 +133,34 @@ func Example() {
 	// Wait for the pool to finish
 	p.Wait()
 }
+
+func doBenchMarkSubmit(b *testing.B, Workers int, N int) {
+	p := NewPool(Workers)
+	j := NewJob(Identifier("Benchmark"), func(c chan struct{}) (interface{}, error) {
+		return nil, nil
+	})
+	b.ResetTimer()
+	for i := 0; i < N; i++ {
+		e := p.Send(j)
+		if e != nil {
+			b.Fatal(e)
+		}
+	}
+	p.Close()
+	_, e := p.Wait()
+	if e != nil {
+		b.Fatal(e)
+	}
+}
+
+func BenchmarkSubmit_1(b *testing.B) {
+	doBenchMarkSubmit(b, 1, b.N)
+}
+
+func BenchmarkSubmit_10(b *testing.B) {
+	doBenchMarkSubmit(b, 10, b.N)
+}
+
+func BenchmarkSubmit_100(b *testing.B) {
+	doBenchMarkSubmit(b, 100, b.N)
+}


### PR DESCRIPTION
Change Log:
- Pool errors are only returned on call to `Error()` and `Wait()`
- Added MIT license
