### PR TITLE
CloseOnError and StreamResultsInto

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _gPool is a lightweight utility for managing a pool of workers._
 	p := gpool.NewPool(5)
 
 	// Example JobFn.
-	// After 10 seconds the job will return Hello, World!
+	// After 10 seconds the job will return 'Hello, World!'
 	JobFn := func(c chan bool) (interface{}, error) {
 		<-time.After(10 * time.Second)
 		return "Hello, World!", nil
@@ -38,7 +38,7 @@ _gPool is a lightweight utility for managing a pool of workers._
 	// jobs is a slice of JobResults of all completed Jobs
 ```
 ### Job
-A `Job` is a task to execute on the `Pool` that contains an `Identifier` and a execution function `PoolJobFn`. It can be any interface that satisfies `gpool.Job` but can also be used with `gpool.NewJob()`.
+A `Job` is a task to execute on the `Pool` that satisfied `gpool.Job`. `gpool.NewJob()` creates a interface{} that contains an `Identifier` and a execution function `JobFn` which can then be submitted to the pool.
 
 ```go
 // Create an Identifer, this in an interface{} which has a String() string method. 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _gPool is a lightweight utility for managing a pool of workers._
 
 	// Example JobFn.
 	// After 10 seconds the job will return Hello, World!
-	JobFn := func(c chan struct{}) (interface{}, error) {
+	JobFn := func(c chan bool) (interface{}, error) {
 		<-time.After(10 * time.Second)
 		return "Hello, World!", nil
 	}
@@ -48,7 +48,7 @@ i := gpool.Identifier("MyTestJob")
 // Create the Job execution function.
 // The job can optionally return an output interface{} and any errors as a result of execution.
 // The c chan will be closed when the Pool is killed, or another job returns a non-nil error.
-fn := func(c chan struct{}) (interface{}, error) {
+fn := func(c chan bool) (interface{}, error) {
   return "Hello, World!", nil
 }
 
@@ -62,7 +62,7 @@ The execution function is given a channel which will be closed when a call to `P
 A call to `Pool.Wait()` will not continue until Jobs in the Pool have completed, so it's important for especially long-running jobs to be able to receive and action this signal in reasonable time.
 
 ```go
-fn := func(c chan struct{}) (interface{}, error) {
+fn := func(c chan bool) (interface{}, error) {
   select {
   case <-c:
     // Cancel signal received, exit without doing anything
@@ -89,10 +89,10 @@ Hook types that are currently available:
 
 ```go
 // HookStart is a function to be called when a Job starts.
-type HookStart func(ID int,j Job)
+type HookStart func(ID int,j gpool.Job)
 
 // HookStop is a function to be called when a Job finishes.
-type HookStop func(ID int,res JobResult)
+type HookStop func(ID int,res gpool.JobResult)
 ```
 
 ### Identifier
@@ -111,7 +111,7 @@ func (c *CopyIdentifier) String() string {
 }
 
 // Example Job
-fn := func(c chan struct{}) (interface{}, error) {
+fn := func(c chan bool) (interface{}, error) {
   return "Hello, World!", nil
 }
 

--- a/job.go
+++ b/job.go
@@ -28,14 +28,14 @@ type JobResult struct {
 
 // JobFn is a function that is executed as a pool Job.
 // c is closed when a Kill() request is issued.
-type JobFn func(c chan struct{}) (interface{}, error)
+type JobFn func(c chan bool) (interface{}, error)
 
 // NewJob creates a interface using the supplied Identifier and Job function that satisfies a PoolJob
 func NewJob(Identifier fmt.Stringer, Fn JobFn) Job {
 	return &job{
 		i:  Identifier,
 		fn: Fn,
-		c:  make(chan struct{}, 1),
+		c:  make(chan bool, 1),
 	}
 }
 
@@ -56,7 +56,7 @@ type job struct {
 	fn JobFn
 	o  interface{}
 	i  fmt.Stringer
-	c  chan struct{}
+	c  chan bool
 }
 
 func (j *job) Run() error {

--- a/pool.go
+++ b/pool.go
@@ -7,9 +7,11 @@ import (
 	"time"
 )
 
-// ErrClosedPool indicates that a send was attempted on a pool which has already been closed
+// ErrClosedPool indicates that a send was attempted on a pool which has already been closed.
 var ErrClosedPool = errors.New("send on closed pool")
 
+// Pool is the main pool struct containing a bus and workers.
+// Pool should always be invoked via NewPool().
 type Pool struct {
 	// Workers
 	wQ chan jobRequest // Queue
@@ -17,15 +19,18 @@ type Pool struct {
 	wC chan struct{}   // Cancel
 	wD chan bool       // Done
 
-	fJ []JobResult
-	iJ int // Job id
+	fJ  []JobResult
+	fJS []chan<- JobResult
+	iJ  int // Job id
 
 	tQ chan ticket // Send ticket requests
 
 	s   *stateManager
 	err error
 	wg  *sync.WaitGroup
-	// Hooks are functions that are executed during different stages of a Job
+	// Hooks are optional functions that are executed during different stages of a Job.
+	// They are invoked by the worker and thus are called concurrently.
+	// The implementor should consider any race conditions for hook callbacks.
 	Hook struct {
 		Start HookStart
 		Stop  HookStop
@@ -58,18 +63,24 @@ func (p *Pool) start() {
 	}
 	go func() {
 		p.wg.Wait()
+		// Cleanup all return streams
+		for _, c := range p.fJS {
+			close(c)
+		}
 		p.wD <- true
 	}()
 	go p.bus()
 }
 
+// ticket request types
 const (
 	tReqJob int = 1 << iota
 	tReqClose
 	tReqKill
 	tReqWait
-	tReqIsOpen
-	tReqHasError
+	tReqStream
+	tReqGetOpen
+	tReqGetError
 )
 
 // A ticket is a request for input in the queue.
@@ -119,6 +130,7 @@ func (p *Pool) Wait() ([]JobResult, error) {
 // Send sends the given PoolJob as a request to the pool bus.
 // If the pool is closed the error ErrClosedPool is returned.
 // No error is returned if the Send() was successful.
+// A call to Send is blocked until a worker accepts the Job.
 func (p *Pool) Send(job Job) error {
 	t := ticket{
 		tReqJob, job, make(chan error),
@@ -130,7 +142,7 @@ func (p *Pool) Send(job Job) error {
 // IsOpen returns true if the pool is currently open.
 func (p *Pool) IsOpen() bool {
 	t := ticket{
-		tReqIsOpen, nil, make(chan error),
+		tReqGetOpen, nil, make(chan error),
 	}
 	p.tQ <- t
 	e := <-t.r
@@ -143,7 +155,24 @@ func (p *Pool) IsOpen() bool {
 // Error returns the current error present in the pool.
 func (p *Pool) Error() error {
 	t := ticket{
-		tReqHasError, nil, make(chan error),
+		tReqGetError, nil, make(chan error),
+	}
+	p.tQ <- t
+	return <-t.r
+}
+
+// StreamInto streams all finished Jobs into the supplied Return channel.
+// The caller is responsible for ensuring the Pool can send to this channel.
+// More than one return channel can be registered.
+// No error is returned if the stream registration was acknowledged.
+// All return channels are closed when the Pool is closed.
+// ErrClosedPool is returned if the pool is already closed.
+func (p *Pool) StreamInto(Return chan<- JobResult) error {
+	if Return == nil {
+		panic("return channel cannot be nil")
+	}
+	t := ticket{
+		tReqStream, Return, make(chan error),
 	}
 	p.tQ <- t
 	return <-t.r
@@ -175,6 +204,10 @@ func (p *Pool) close(kill bool) bool {
 
 // res receives a JobResult and processes it.
 func (p *Pool) res(resp JobResult) {
+	// Send result to each return channel
+	for _, c := range p.fJS {
+		c <- resp
+	}
 	if resp.Error != nil {
 		p.err = resp.Error
 		p.close(true)
@@ -199,10 +232,9 @@ func (p *Pool) doSend(r jobRequest) {
 // bus is the central communication bus for the pool.
 // All pool inputs are collected here as tickets and then actioned on depending on the ticket type.
 // If the ticket is a tReqWait request they are added to the slice of pending tickets and upon pool closure
-// the ticket return channel is sent any pool errors.
 func (p *Pool) bus() {
 	// Pending tReqWaits
-	pending := []ticket{}
+	pendWait := []ticket{}
 	for {
 		select {
 		case <-p.wD:
@@ -246,27 +278,36 @@ func (p *Pool) bus() {
 				}
 			// Pool wait request
 			case tReqWait:
-				pending = append(pending, t)
+				pendWait = append(pendWait, t)
 			// Pool is open request
-			case tReqIsOpen:
+			case tReqGetOpen:
 				if p.done || p.err != nil || p.closed {
 					t.r <- ErrClosedPool
 					continue
 				}
 				t.r <- nil
-			case tReqHasError:
+			case tReqGetError:
 				t.r <- p.err
+			case tReqStream:
+				if p.done || p.err != nil || p.closed {
+					t.r <- ErrClosedPool
+					continue
+				}
+				p.fJS = append(p.fJS, t.data.(chan<- JobResult))
+				t.r <- nil
+			default:
+				panic("unknown ticket type")
 			}
 		// Default case resolves any pending tickets
 		default:
-			if p.done && len(pending) != 0 {
+			if p.done && len(pendWait) != 0 {
 				// Pop every item in pending and send return signal to ticket
 				for {
-					if len(pending) == 0 {
+					if len(pendWait) == 0 {
 						break
 					}
 					var t ticket
-					t, pending = pending[len(pending)-1], pending[:len(pending)-1]
+					t, pendWait = pendWait[len(pendWait)-1], pendWait[:len(pendWait)-1]
 					t.r <- p.err
 				}
 			}


### PR DESCRIPTION
Change Log:
- Cancel receiver for `JobFn` is now `chan bool`
- `CloseOnError()` for closing a supplied channel on error
- `StreamResultInto()` for streaming pool output
