### PR TITLE
Grow() and Job status

### DIFF
--- a/job.go
+++ b/job.go
@@ -20,10 +20,10 @@ func (s Identifier) String() string {
 
 // JobResult is the result of an execution in the Pool
 type JobResult struct {
-	ID       int
-	Job      Job
-	Duration time.Duration
-	Error    error
+	ID       int           // Unique Job ID
+	Job      Job           // Underlying Job
+	Duration time.Duration // Execution duration
+	Error    error         // Wrapped PoolError containing the underlying error from Job.Run()
 }
 
 // JobFn is a function that is executed as a pool Job.

--- a/pool_test.go
+++ b/pool_test.go
@@ -105,9 +105,18 @@ func Test_Pool_IsOpen(t *testing.T) {
 
 func Test_Pool_Error(t *testing.T) {
 	p := NewPool(1)
-	p.Send(NewJob(Identifier("Testing"), failJob))
-	p.Close()
-	p.Wait()
+	e := p.Send(NewJob(Identifier("Testing"), failJob))
+	if e != nil {
+		t.Fatal(e)
+	}
+	e = p.Close()
+	if e != nil {
+		t.Fatal(e)
+	}
+	_, e = p.Wait()
+	if e == nil {
+		t.Fatal("expected error")
+	}
 
 	if e := p.Error(); e == nil {
 		t.Fatal("no pool error")
@@ -130,7 +139,14 @@ func Test_Pool_Kill(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("no job response after 2 seconds")
 	}
-	p.Close()
+	e := p.Close()
+	if e != nil {
+		t.Fatal("expected error, got", e)
+	}
+	_, e = p.Wait()
+	if e != ErrKilled {
+		t.Fatal("expected ErrKilled, got", e)
+	}
 }
 
 func Test_Pool_NRunning(t *testing.T) {


### PR DESCRIPTION
Change Log:
- `Grow(int)` worker count by requested size
- Fix infinite block on a call to `Close()` on already closed pool
- Added `JobState()` to inspect amount of running and finished jobs
