### PR TITLE
Fix 100% Single Core Utilisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ The bus is the central communication loop which mediates input requests in a thr
 All pool requests are sent to the bus and then resolved, concurrent requests are resolved in order preventing any race conditions.
 Because of this, any blocking requests such as `Pool.Send()` will block any further requests until the send is resolved.
 
-The exception is `Pool.Wait()` where wait requests are stacked until they can be resolved.
-Wait request resolution happens every bus cycle where no other message has been received.
+The exception is `Pool.Wait()` where if the pool is not closed at request time, requests are stacked until the pool is complete. 
+Unless the pool is already closed in which wait requests are resolved instantly.
 
 Once started (via `NewPool()`) the bus cannot be killed, this is to prevent any message from not being acknowledged and thus causing a deadlock.
 If you have a suggestion for destroying the bus that prevents any messages from not being acknowledged please raise a pull request for the fix.

--- a/pool.go
+++ b/pool.go
@@ -139,10 +139,10 @@ func (p *Pool) Close() error {
 
 // Wait waits for the pool worker group to finish and then returns all jobs completed during execution.
 // If the pool has an error it is returned here.
-// Wait will block until the pool is marked as done (via call to Pool.Close) or has an error.
+// Wait will block until all of the workers in the pool have exited.
 // As such it is important that the caller either implements a timeout around Wait,
 // or ensures a call to Pool.Close will be made.
-// Wait requests are stacked until they can be resolved in the next bus cycle.
+// If all workers have already exited Wait() is resolved instantly.
 func (p *Pool) Wait() ([]JobResult, error) {
 	return p.fJ, p.ack(newTicket(tReqWait, nil))
 }
@@ -210,7 +210,7 @@ type jobRequest struct {
 
 // close closes the pool if not already closed.
 // Returns true if the pool was closed.
-func (p *Pool) close(kill bool) bool {
+func (p *Pool) close(kill bool, tickets ...ticket) bool {
 	if !p.killed && kill {
 		p.killed = true
 		if p.err == nil {
@@ -284,6 +284,8 @@ func (p *Pool) bus() {
 		case <-p.wD:
 			p.close(false)
 			p.done = true
+			// Workers are done so resolve all wait tickets
+			pendWait = p.resolve(p.err, pendWait...)
 		// Receive worker response
 		case resp := <-p.wR:
 			p.res(resp)
@@ -325,6 +327,11 @@ func (p *Pool) bus() {
 				}
 			// Pool wait request
 			case tReqWait:
+				// If done resolve ticket instantly
+				if p.done {
+					p.resolve(p.err, t)
+					continue
+				}
 				pendWait = append(pendWait, t)
 			case tReqGrow:
 				i := t.data.(int)
@@ -358,11 +365,6 @@ func (p *Pool) bus() {
 				t.r <- p.err
 			default:
 				panic("unknown ticket type")
-			}
-		// Default case resolves any pending tickets
-		default:
-			if p.done {
-				pendWait = p.resolve(p.err, pendWait...)
 			}
 		}
 

--- a/pool.go
+++ b/pool.go
@@ -70,7 +70,8 @@ func NewPool(Workers int) *Pool {
 
 // start starts Pool workers and Pool bus
 func (p *Pool) start() {
-	for range make([]int, p.s.GetTarget()) {
+	_, t := p.s.WorkerState()
+	for range make([]int, t) {
 		p.startWorker()
 	}
 	go func() {
@@ -330,7 +331,7 @@ func (p *Pool) bus() {
 				if p.unhealthy() {
 					t.r <- ErrClosedPool
 				}
-				p.s.IncrTarget(i)
+				p.s.AdjTarget(i)
 				p.resolveWorker()
 				t.r <- nil
 			case tReqShrink:
@@ -339,7 +340,7 @@ func (p *Pool) bus() {
 					t.r <- ErrClosedPool
 				}
 				if _, target := p.s.WorkerState(); (target - i) > 0 {
-					p.s.DecTarget(i)
+					p.s.AdjTarget(-i)
 					p.resolveWorker()
 					t.r <- nil
 				} else {

--- a/pool_test.go
+++ b/pool_test.go
@@ -16,6 +16,19 @@ var goodJob = func(c chan bool) (interface{}, error) {
 	return nil, nil
 }
 
+func Test_Pool_Wait(t *testing.T) {
+	p := NewPool(1)
+	ok := make(chan bool)
+	go func() {
+		p.Wait()
+		close(ok)
+	}()
+	p.Kill()
+	p.Wait()
+	p.Wait()
+	<-ok
+}
+
 func Test_Pool_JobError(t *testing.T) {
 	p := NewPool(1)
 	p.Send(NewJob(Identifier("Testing"), failJob))


### PR DESCRIPTION
Change Log:
- Fixed issue where a sleeping pool would utilise 100% of one core
- Use `RWMutex` for marginally faster state tracking
