### PR TITLE
Resize(), remove unused ack channel

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -236,6 +236,20 @@ func Test_Pool_Shrink_Neg(t *testing.T) {
 	p.Wait()
 }
 
+func Test_Pool_Resize(t *testing.T) {
+	p := NewPool(1)
+	e := p.Resize(5)
+	if e != nil {
+		t.Fatal(e)
+	}
+
+	if c, _ := p.s.workers(); c != 5 {
+		t.Fatal("worker state incorrect, wanted 5, got", c)
+	}
+	p.Kill()
+	p.Wait()
+}
+
 func Test_Pool_JobState(t *testing.T) {
 	p := NewPool(1)
 	ok := make(chan bool)

--- a/state.go
+++ b/state.go
@@ -59,6 +59,12 @@ func (s *stateManager) Job() func(j JobResult) {
 	}
 }
 
+func (s *stateManager) SetTarget(Target int) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.tW = Target
+}
+
 func (s *stateManager) AdjTarget(Delta int) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()


### PR DESCRIPTION
Change Log:
- `Pool.Resize` method
- Code cleanup and edge case prevention
